### PR TITLE
replace "investigation" by "study" in the study properties table

### DIFF
--- a/source/_static/model/study.csv
+++ b/source/_static/model/study.csv
@@ -1,9 +1,9 @@
 Property,Datatype,Description
 Identifier,String,A identifier or an accession number provided by a repository. This SHOULD be locally unique.
-Title,String,A concise name given to the investigation.
-Description,String,A textual description of the investigation.
-Submission Date,Representation of a ISO8601 date,The date on which the investigation was reported to the repository.
-Public Release Date,Representation of a ISO8601 date,The date on which the investigation was released publicly.
+Title,String,A concise name given to the study.
+Description,String,A textual description of the study.
+Submission Date,Representation of a ISO8601 date,The date on which the study was reported to the repository.
+Public Release Date,Representation of a ISO8601 date,The date on which the study was released publicly.
 Publications,A list of Publication,A list of Publications relating to the study.
 Contacts,A list of Contact,A list of Contacts relating to the study.
 Design Type,Ontology Annotation,"A classifier of the study based on the overall experimental design, e.g cross-over design or parallel group design."


### PR DESCRIPTION
In the description of properties in the table, sometimes the word "investigation" is provided instead of "study". This was fixed.

<img width="753" alt="image" src="https://user-images.githubusercontent.com/82588017/189943199-16e5efee-6574-406c-83e2-b4bfb21044f0.png">
