### PR TITLE
Update isajson schema to draft 07

### DIFF
--- a/source/_static/isajson/assay_schema.json
+++ b/source/_static/isajson/assay_schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Assay JSON Schema",
   "name": "Assay JSON Schema",
   "description": "JSON Schema describing an Assay",

--- a/source/_static/isajson/assay_schema.json
+++ b/source/_static/isajson/assay_schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Assay JSON Schema",
   "name": "Assay JSON Schema",
   "description": "JSON Schema describing an Assay",
@@ -9,7 +9,7 @@
   },
   "type": "object",
   "properties": {
-    "@id": { "type": "string", "format": "uri" },
+    "@id": { "type": "string", "format": "uri-reference" },
     "comments" : {
       "type": "array",
       "items": {

--- a/source/_static/isajson/comment_schema.json
+++ b/source/_static/isajson/comment_schema.json
@@ -1,10 +1,10 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema",
+    "$schema": "http://json-schema.org/draft-06/schema",
     "title": "ISA comment schema - it corresponds to ISA Comment[] construct",
     "description": "JSON-schema representing a comment in the ISA model",
     "type": "object",
     "properties": {
-        "@id": { "type": "string", "format": "uri" },
+        "@id": { "type": "string", "format": "uri-reference" },
         "name": {
             "type": "string"
         },

--- a/source/_static/isajson/comment_schema.json
+++ b/source/_static/isajson/comment_schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "title": "ISA comment schema - it corresponds to ISA Comment[] construct",
     "description": "JSON-schema representing a comment in the ISA model",
     "type": "object",

--- a/source/_static/isajson/data_schema.json
+++ b/source/_static/isajson/data_schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "title": "ISA data schema",
     "description": "JSON-schema representing a data file in the ISA model",
     "type": "object",

--- a/source/_static/isajson/data_schema.json
+++ b/source/_static/isajson/data_schema.json
@@ -1,10 +1,10 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema",
+    "$schema": "http://json-schema.org/draft-06/schema",
     "title": "ISA data schema",
     "description": "JSON-schema representing a data file in the ISA model",
     "type": "object",
     "properties": {
-        "@id": { "type": "string", "format": "uri" },
+        "@id": { "type": "string", "format": "uri-reference" },
         "name": {
             "type": "string"
         },

--- a/source/_static/isajson/factor_schema.json
+++ b/source/_static/isajson/factor_schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "title": "ISA factor schema",
     "name": "ISA factor schema",
     "description": "JSON-schema representing a factor value in the ISA model",

--- a/source/_static/isajson/factor_schema.json
+++ b/source/_static/isajson/factor_schema.json
@@ -1,11 +1,11 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema",
+    "$schema": "http://json-schema.org/draft-06/schema",
     "title": "ISA factor schema",
     "name": "ISA factor schema",
     "description": "JSON-schema representing a factor value in the ISA model",
     "type": "object",
     "properties": {
-        "@id": { "type": "string", "format": "uri" },
+        "@id": { "type": "string", "format": "uri-reference" },
         "factorName": {
             "type": "string"
         },

--- a/source/_static/isajson/factor_value_schema.json
+++ b/source/_static/isajson/factor_value_schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "title": "ISA factor value schema",
     "description": "JSON-schema representing a factor value in the ISA model",
     "type": "object",

--- a/source/_static/isajson/factor_value_schema.json
+++ b/source/_static/isajson/factor_value_schema.json
@@ -1,10 +1,10 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema",
+    "$schema": "http://json-schema.org/draft-06/schema",
     "title": "ISA factor value schema",
     "description": "JSON-schema representing a factor value in the ISA model",
     "type": "object",
     "properties": {
-         "@id": { "type": "string", "format": "uri" },
+         "@id": { "type": "string", "format": "uri-reference" },
          "category" : {
              "$ref": "factor_schema.json#"
         },

--- a/source/_static/isajson/investigation_schema.json
+++ b/source/_static/isajson/investigation_schema.json
@@ -11,7 +11,7 @@
         "description" : { "type" : "string"},
         "submissionDate" : {
             "type": "string",
-            "anyOf": [
+            "oneOf": [
                {
                  "format": "date-time"
                },
@@ -23,7 +23,7 @@
         },
         "publicReleaseDate" :{
             "type": "string",
-            "anyOf": [
+            "oneOf": [
                {
                  "format": "date-time"
                },

--- a/source/_static/isajson/investigation_schema.json
+++ b/source/_static/isajson/investigation_schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "title" : "ISA investigation schema",
     "description" : "JSON-schema representing an investigation in the ISA model",
     "type" : "object",
@@ -9,8 +9,30 @@
         "identifier" : { "type" : "string" },
         "title" : { "type" : "string"},
         "description" : { "type" : "string"},
-        "submissionDate" : { "type" : "string", "format" : "date-time"},
-        "publicReleaseDate" : { "type" : "string", "format" : "date-time"},
+        "submissionDate" : {
+            "type": "string",
+            "anyOf": [
+               {
+                 "format": "date-time"
+               },
+               {
+                 "format": "date"
+               }
+             ]
+
+        },
+        "publicReleaseDate" :{
+            "type": "string",
+            "anyOf": [
+               {
+                 "format": "date-time"
+               },
+               {
+                 "format": "date"
+               }
+             ]
+
+        },
         "ontologySourceReferences" : {
             "type" : "array",
             "items" : {

--- a/source/_static/isajson/investigation_schema.json
+++ b/source/_static/isajson/investigation_schema.json
@@ -1,10 +1,10 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema",
+    "$schema": "http://json-schema.org/draft-06/schema",
     "title" : "ISA investigation schema",
     "description" : "JSON-schema representing an investigation in the ISA model",
     "type" : "object",
     "properties" : {
-         "@id": { "type": "string", "format": "uri" },
+         "@id": { "type": "string", "format": "uri-reference" },
         "filename": { "type" : "string"},
         "identifier" : { "type" : "string" },
         "title" : { "type" : "string"},

--- a/source/_static/isajson/material_attribute_schema.json
+++ b/source/_static/isajson/material_attribute_schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "title" : "ISA material attribute schema",
     "description" : "JSON-schema representing a characteristics category (what appears between the brackets in Charactersitics[]) in the ISA model",
     "type" : "object",

--- a/source/_static/isajson/material_attribute_schema.json
+++ b/source/_static/isajson/material_attribute_schema.json
@@ -1,10 +1,10 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema",
+    "$schema": "http://json-schema.org/draft-06/schema",
     "title" : "ISA material attribute schema",
     "description" : "JSON-schema representing a characteristics category (what appears between the brackets in Charactersitics[]) in the ISA model",
     "type" : "object",
     "properties" : {
-        "@id": { "type": "string", "format": "uri" },
+        "@id": { "type": "string", "format": "uri-reference" },
         "characteristicType": {
             "$ref": "ontology_annotation_schema.json#"
         }

--- a/source/_static/isajson/material_attribute_value_schema.json
+++ b/source/_static/isajson/material_attribute_value_schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "title" : "ISA material attribute schema",
     "description" : "JSON-schema representing a material attribute (or characteristic) value in the ISA model",
     "type" : "object",

--- a/source/_static/isajson/material_attribute_value_schema.json
+++ b/source/_static/isajson/material_attribute_value_schema.json
@@ -1,10 +1,10 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema",
+    "$schema": "http://json-schema.org/draft-06/schema",
     "title" : "ISA material attribute schema",
     "description" : "JSON-schema representing a material attribute (or characteristic) value in the ISA model",
     "type" : "object",
     "properties" : {
-         "@id": { "type": "string", "format": "uri" },
+         "@id": { "type": "string", "format": "uri-reference" },
         "category" : {
              "$ref": "material_attribute_schema.json#"
         },

--- a/source/_static/isajson/material_schema.json
+++ b/source/_static/isajson/material_schema.json
@@ -1,10 +1,10 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-06/schema",
   "title" : "ISA material node schema",
   "description" : "JSON-schema representing a material node in the ISA model, which is not a source or a sample (as they have specific schemas) - this will correspond to 'Extract Name', 'Labeled Extract Name'",
   "type" : "object",
   "properties" : {
-    "@id": { "type": "string", "format": "uri" },
+    "@id": { "type": "string", "format": "uri-reference" },
     "name" : { "type" : "string" },
     "type": {
       "type": "string",

--- a/source/_static/isajson/material_schema.json
+++ b/source/_static/isajson/material_schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-06/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "title" : "ISA material node schema",
   "description" : "JSON-schema representing a material node in the ISA model, which is not a source or a sample (as they have specific schemas) - this will correspond to 'Extract Name', 'Labeled Extract Name'",
   "type" : "object",

--- a/source/_static/isajson/ontology_annotation_schema.json
+++ b/source/_static/isajson/ontology_annotation_schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "title" : "ISA ontology reference schema",
     "name" : "ISA ontology reference schema",
     "description" : "JSON-schema representing an ontology reference or annotation in the ISA model (for fields that are required to be ontology annotations)",

--- a/source/_static/isajson/ontology_annotation_schema.json
+++ b/source/_static/isajson/ontology_annotation_schema.json
@@ -1,11 +1,11 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema",
+    "$schema": "http://json-schema.org/draft-06/schema",
     "title" : "ISA ontology reference schema",
     "name" : "ISA ontology reference schema",
     "description" : "JSON-schema representing an ontology reference or annotation in the ISA model (for fields that are required to be ontology annotations)",
     "type" : "object",
     "properties" : {
-        "@id": { "type": "string", "format": "uri" },
+        "@id": { "type": "string", "format": "uri-reference" },
         "annotationValue": {
             "anyOf": [
                 { "type": "string" },

--- a/source/_static/isajson/ontology_source_reference_schema.json
+++ b/source/_static/isajson/ontology_source_reference_schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "title" : "ISA ontology source reference schema",
     "name" : "ISA ontology source reference schema",
     "description" : "JSON-schema representing an ontology reference in the ISA model",

--- a/source/_static/isajson/ontology_source_reference_schema.json
+++ b/source/_static/isajson/ontology_source_reference_schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema",
+    "$schema": "http://json-schema.org/draft-06/schema",
     "title" : "ISA ontology source reference schema",
     "name" : "ISA ontology source reference schema",
     "description" : "JSON-schema representing an ontology reference in the ISA model",

--- a/source/_static/isajson/person_schema.json
+++ b/source/_static/isajson/person_schema.json
@@ -1,10 +1,10 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema",
+    "$schema": "http://json-schema.org/draft-06/schema",
     "title" : "ISA person schema",
     "description" : "JSON-schema representing a person in the ISA model",
     "type" : "object",
     "properties" : {
-        "@id": { "type": "string", "format": "uri" },
+        "@id": { "type": "string", "format": "uri-reference" },
         "lastName" : { "type" : "string"},
         "firstName" : { "type" : "string"},
         "midInitials" : { "type" : "string" },

--- a/source/_static/isajson/person_schema.json
+++ b/source/_static/isajson/person_schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "title" : "ISA person schema",
     "description" : "JSON-schema representing a person in the ISA model",
     "type" : "object",

--- a/source/_static/isajson/process_parameter_value_schema.json
+++ b/source/_static/isajson/process_parameter_value_schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema",
+    "$schema": "http://json-schema.org/draft-06/schema",
     "title" : "ISA process parameter value schema",
     "description" : "JSON-schema representing a Parameter Value (associated with a Protocol REF) in the ISA model",
     "type" : "object",

--- a/source/_static/isajson/process_parameter_value_schema.json
+++ b/source/_static/isajson/process_parameter_value_schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "title" : "ISA process parameter value schema",
     "description" : "JSON-schema representing a Parameter Value (associated with a Protocol REF) in the ISA model",
     "type" : "object",

--- a/source/_static/isajson/process_schema.json
+++ b/source/_static/isajson/process_schema.json
@@ -22,7 +22,7 @@
         },
         "date": {
              "type": "string",
-             "anyOf": [
+             "oneOf": [
                 {
                   "format": "date-time"
                 },

--- a/source/_static/isajson/process_schema.json
+++ b/source/_static/isajson/process_schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "title": "ISA process or protocol application schema, corresponds to 'Protocol REF' columns in the study and assay files",
     "description": "JSON-schema representing a protocol application in the ISA model",
     "type": "object",
@@ -22,7 +22,15 @@
         },
         "date": {
              "type": "string",
-              "format": "date-time"
+             "anyOf": [
+                {
+                  "format": "date-time"
+                },
+                {
+                  "format": "date"
+                }
+              ]
+
         },
         "previousProcess" : {
              "$ref" : "process_schema.json#"

--- a/source/_static/isajson/process_schema.json
+++ b/source/_static/isajson/process_schema.json
@@ -1,10 +1,10 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema",
+    "$schema": "http://json-schema.org/draft-06/schema",
     "title": "ISA process or protocol application schema, corresponds to 'Protocol REF' columns in the study and assay files",
     "description": "JSON-schema representing a protocol application in the ISA model",
     "type": "object",
     "properties": {
-        "@id": { "type": "string", "format": "uri" },
+        "@id": { "type": "string", "format": "uri-reference" },
         "name": {
             "type": "string"
         },

--- a/source/_static/isajson/protocol_parameter_schema.json
+++ b/source/_static/isajson/protocol_parameter_schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "title" : "ISA protocol parameter schema",
     "description" : "JSON-schema representing a parameter for a protocol (category declared in the investigation file) in the ISA model",
     "type" : "object",

--- a/source/_static/isajson/protocol_parameter_schema.json
+++ b/source/_static/isajson/protocol_parameter_schema.json
@@ -1,10 +1,10 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema",
+    "$schema": "http://json-schema.org/draft-06/schema",
     "title" : "ISA protocol parameter schema",
     "description" : "JSON-schema representing a parameter for a protocol (category declared in the investigation file) in the ISA model",
     "type" : "object",
     "properties" : {
-        "@id": { "type": "string", "format": "uri" },
+        "@id": { "type": "string", "format": "uri-reference" },
         "parameterName": {
             "$ref": "ontology_annotation_schema.json#"
         }

--- a/source/_static/isajson/protocol_schema.json
+++ b/source/_static/isajson/protocol_schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema",
+    "$schema": "http://json-schema.org/draft-08/schema",
     "title": "ISA protocol schema",
     "name": "ISA protocol schema",
     "description": "JSON-schema representing a protocol in the ISA model",

--- a/source/_static/isajson/protocol_schema.json
+++ b/source/_static/isajson/protocol_schema.json
@@ -1,11 +1,11 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema",
+    "$schema": "http://json-schema.org/draft-06/schema",
     "title": "ISA protocol schema",
     "name": "ISA protocol schema",
     "description": "JSON-schema representing a protocol in the ISA model",
     "type": "object",
     "properties": {
-        "@id": { "type": "string", "format": "uri" },
+        "@id": { "type": "string", "format": "uri-reference" },
         "comments" : {
             "type": "array",
             "items": {

--- a/source/_static/isajson/publication_schema.json
+++ b/source/_static/isajson/publication_schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "title" : "ISA investigation schema",
     "name" : "ISA investigation schema",
     "description" : "JSON-schema representing an investigation in the ISA model",

--- a/source/_static/isajson/publication_schema.json
+++ b/source/_static/isajson/publication_schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema",
+    "$schema": "http://json-schema.org/draft-06/schema",
     "title" : "ISA investigation schema",
     "name" : "ISA investigation schema",
     "description" : "JSON-schema representing an investigation in the ISA model",

--- a/source/_static/isajson/sample_schema.json
+++ b/source/_static/isajson/sample_schema.json
@@ -1,10 +1,10 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema",
+    "$schema": "http://json-schema.org/draft-06/schema",
     "title" : "ISA sample schema",
     "description" : "JSON-schema representing a sample in the ISA model. A sample represents a major output resulting from a protocol application other than the special case outputs of Extract or a Labeled Extract.",
     "type": "object",
     "properties" : {
-        "@id": { "type": "string", "format": "uri" },
+        "@id": { "type": "string", "format": "uri-reference" },
         "name" : { "type" : "string" },
         "characteristics" : {
             "type" : "array",

--- a/source/_static/isajson/sample_schema.json
+++ b/source/_static/isajson/sample_schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "title" : "ISA sample schema",
     "description" : "JSON-schema representing a sample in the ISA model. A sample represents a major output resulting from a protocol application other than the special case outputs of Extract or a Labeled Extract.",
     "type": "object",

--- a/source/_static/isajson/source_schema.json
+++ b/source/_static/isajson/source_schema.json
@@ -1,9 +1,9 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema",
+    "$schema": "http://json-schema.org/draft-06/schema",
     "title" : "ISA source schema",
     "description" : "JSON-schema representing a source in the ISA model. Sources are considered as the starting biological material used in a study.",
       "properties" : {
-        "@id": { "type": "string", "format": "uri" },
+        "@id": { "type": "string", "format": "uri-reference" },
         "name" : { "type" : "string" },
         "characteristics" : {
             "type" : "array",

--- a/source/_static/isajson/source_schema.json
+++ b/source/_static/isajson/source_schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "title" : "ISA source schema",
     "description" : "JSON-schema representing a source in the ISA model. Sources are considered as the starting biological material used in a study.",
       "properties" : {

--- a/source/_static/isajson/study_schema.json
+++ b/source/_static/isajson/study_schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Study JSON Schema",
   "description": "JSON Schema describing an Study",
   "@context": {
@@ -8,7 +8,7 @@
   },
   "type": "object",
   "properties": {
-    "@id": { "type": "string", "format": "uri" },
+    "@id": { "type": "string", "format": "uri-reference" },
     "filename" : { "type" : "string"},
     "identifier" : { "type" : "string" },
     "title" : { "type" : "string"},

--- a/source/_static/isajson/study_schema.json
+++ b/source/_static/isajson/study_schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Study JSON Schema",
   "description": "JSON Schema describing an Study",
   "@context": {
@@ -13,8 +13,30 @@
     "identifier" : { "type" : "string" },
     "title" : { "type" : "string"},
     "description" : { "type" : "string"},
-    "submissionDate" : { "type" : "string", "format" : "date-time"},
-    "publicReleaseDate" : { "type" : "string", "format" : "date-time"},
+    "submissionDate" : {
+      "type": "string",
+      "anyOf": [
+         {
+           "format": "date-time"
+         },
+         {
+           "format": "date"
+         }
+       ]
+
+    },
+    "publicReleaseDate" : {
+      "type": "string",
+      "anyOf": [
+         {
+           "format": "date-time"
+         },
+         {
+           "format": "date"
+         }
+       ]
+
+    },
     "publications" : {
       "type" : "array",
       "items" : {

--- a/source/_static/isajson/study_schema.json
+++ b/source/_static/isajson/study_schema.json
@@ -15,7 +15,7 @@
     "description" : { "type" : "string"},
     "submissionDate" : {
       "type": "string",
-      "anyOf": [
+      "oneOf": [
          {
            "format": "date-time"
          },
@@ -27,7 +27,7 @@
     },
     "publicReleaseDate" : {
       "type": "string",
-      "anyOf": [
+      "oneOf": [
          {
            "format": "date-time"
          },


### PR DESCRIPTION
In some fields, the `isajson` schema is too strict to pass validation for the example files provided here: https://github.com/ISA-tools/ISAdatasets/tree/master/json

This is because of two types of fields, namely the `@id` fields and the `date` fields. 
- `@id` fields are defined in the schemas to only validate against strings of format `uri`, which expects full uris like `http://example.org/wiki/Main_Page`. In contrast to this, ids like `"#sample/sample-N-0.2-aliquot2"` are used, which seems sensible to do but fails the validation. Using the format specification `uri-reference` instead of `uri` could soften this up, but requires `json schema draft 06`.
- `@date` fields are defined in the schemas to only validate against strings of format `date-time`, which expects full date and time information like `2020-05-04T02:15:00.0Z` but fails when just specifying the date. I propose to use an `any-of` between `date-time` and `date`, which requires `json schema draft 07`.

In this PR are my requested changes, upping the json schema draft version and using the aforementioned string format specification changes.

The example files also contain other errors causing the validation to fail, but these are actual format errors like empty strings when a URI should be given. I will open up an issue there